### PR TITLE
[FIX] 모달을 닫을 때 버튼을 사용하지 않으면 동일한 모달이 다시 열리지 않는 버그 수정

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -144,7 +144,12 @@ function DialogContainer({
   };
 
   return (
-    <Dialog defaultOpen>
+    <Dialog
+      defaultOpen
+      onOpenChange={(open) => {
+        if (!open) closeModal();
+      }}
+    >
       <DialogContent className="sm:max-w-[425px]">
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>


### PR DESCRIPTION
- 모달을 닫을 때 cancel 또는 confirm 버튼으로 닫지 않는 경우, 화면에서는 모달이 사라지지만 실제로는 남아있어서 다시 동일한 타입의 모달을 열려고 할 때 안열리는 버그 수정.
: Dialog 컴포넌트에 (modal container역할?) modal open 상태 변경시, close로 바뀌는 경우 명시적으로 closeModal() 메서드를 호출해 제대로 닫기도록 수정.

- asis

https://github.com/user-attachments/assets/03bf477b-a4b7-4dfb-9c92-9549078a27df

- tobe

https://github.com/user-attachments/assets/3a182a3b-1fa0-4369-8435-1f523a9345ee

